### PR TITLE
chore: update to 0.12.4 + sync from snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 ARG UPSTREAM_VERSION
-FROM nethermindeth/juno:${UPSTREAM_VERSION}
+FROM nethermind/juno:${UPSTREAM_VERSION}
 
-RUN mkdir -p home/juno
+RUN apt-get install -y wget \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /var/lib/juno
 
-ENTRYPOINT juno
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["bash", "-c", "./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -4,22 +4,14 @@
 
 Wrapper around Nethermind Juno to run a Starknet full node giving you a safe view into StarkNet network, helping to keep the network secure and the data accurate.
 
-Juno is a golang Starknet node implementation by Nethermind with the aim of decentralising Starknet.
+Juno is a Go implementation of a Starknet full-node client created by Nethermind to allow node operators to easily and reliably support the network and advance its decentralisation goals. See the [Juno website](https://juno.nethermind.io/)
 
-## ✔ Supported Features
 
-- Starknet state construction and storage using a path-based Merkle Patricia trie. 
-- Pedersen and `starknet_keccak` hash implementation over starknet field.
-- Feeder gateway synchronisation of Blocks, Transactions, Receipts, State Updates and Classes.
-- Block and Transaction hash verification.
-- JSON-RPC Endpoints:
-  - `starknet_chainId`
-  - `starknet_blockNumber`
-  - `starknet_blockHashAndNumber`
-  - `starknet_getBlockWithTxHashes`
-  - `starknet_getBlockWithTxs`
-  - `starknet_getTransactionByHash`
-  - `starknet_getTransactionReceipt`
-  - `starknet_getBlockTransactionCount`
-  - `starknet_getTransactionByBlockIdAndIndex`
-  - `starknet_getStateUpdate`
+## DappNode configuration
+
+`ETH_L1_RPC_URL`: To enable L1 verification, provide the Websocket endpoint of a running Ethereum node. Leave empty to skip verification. See `eth-node` parameter in [Configuration options](https://juno.nethermind.io/configuring#configuration-options)
+
+`SNAPSHOT_URL`: To speed up first sync, set a snapshot URL. Default is the latest mainnet snapshot from Nethermind. Leave empty to sync from scratch. See [Snapshots](https://juno.nethermind.io/snapshots). 
+> Note: a failed snapshot download may leave files in the snapshot directory and will skip downloading at the next restart. To force a snapshot download, delete the package and reinstall. 
+
+`EXTRA_OPTS`: Additional configuration options. See [Configuration options](https://juno.nethermind.io/configuring#configuration-options)

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,11 +1,14 @@
 {
   "name": "juno.public.dappnode.eth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "shortDescription": "StarkNet full node",
   "description": "Nethermind Starknet Node Client Juno",
   "type": "service",
-  "chain": "ethereum",
-  "author": "0xVato",
+  "author": "Artur Vargas <arturvargas9226@gmail.com> (https://github.com/ArturVargas)",
+  "contributors": [
+    "Artur Vargas <arturvargas9226@gmail.com> (https://github.com/ArturVargas)",
+    "Louis Garoche <louis@garoche.me> (https://github.com/lgaroche)"
+  ],
   "categories": [
     "Developer tools"
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,18 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v0.2.2
-    image: "dappnode_juno.public.dappnode.eth.juno.public.dappnode.eth:0.1.0"
+        UPSTREAM_VERSION: v0.12.4
+    image: "dappnode_juno.public.dappnode.eth.juno.public.dappnode.eth:0.1.1"
+    security_opt:
+      - seccomp:unconfined
     ports:
       - "6060:6060"
     environment:
-      RUST_LOG: info
-      JUNO_HTTP_RPC_ADDRESS: "0.0.0.0:6060"
+      ETH_L1_RPC_URL: "ws://nethermind.public.dappnode:8545"
+      SNAPSHOT_URL: "https://juno-snapshots.nethermind.dev/files/mainnet/latest"
+      EXTRA_OPTS: ""
     volumes:
-      - "juno_data:/root/.local/share/juno/mainnet"
+      - "juno_data:/var/lib/juno"
     restart: unless-stopped
 volumes:
   juno_data: {}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+JUNO_DIR=/var/lib/juno
+
+echo "Starting Juno node with the following parameters:"
+echo "Juno data directory: $JUNO_DIR"
+echo "Snapshot URL: $SNAPSHOT_URL"
+echo "Ethereum L1 RPC URL: $ETH_L1_RPC_URL"
+echo "Extra options: $EXTRA_OPTS"
+
+# if dir is empty and URL is configured, download the snapshot
+if [ "$(ls -A $JUNO_DIR)" ]; then
+  echo "Skipping snapshot download."
+elif [ -n "$SNAPSHOT_URL" ]; then
+  echo "Juno data directory is empty. Downloading snapshot."
+  snapshot=mainnet.tar
+  wget --progress=dot:giga -O $snapshot $SNAPSHOT_URL
+  tar --checkpoint=65536 -xf $snapshot -C $JUNO_DIR
+  rm $snapshot
+fi
+
+ethnode=""
+if [ -n "$ETH_L1_RPC_URL" ]; then
+  echo "Using Ethereum node to verify the state on L1."
+  ethnode="--eth-node $ETH_L1_RPC_URL"
+fi
+
+juno \
+  --http \
+  --http-port 6060 \
+  --http-host 0.0.0.0 \
+  --db-path $JUNO_DIR \
+  $ethnode $EXTRA_OPTS


### PR DESCRIPTION
1. Update to use the latest Juno version: 0.12.4
1. Add a startup script that fetches the lastest snapshot from Nethermind. Can ben skipped it needed.
1. Add a optional L1 configuration for verification