### PR TITLE
Feat/staking v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG UPSTREAM_VERSION
 FROM nethermind/juno:${UPSTREAM_VERSION}
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget \
+RUN apt-get update && apt-get install -y --no-install-recommends wget zstd \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/lib/juno

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Or using the full domain:
 
 ## DappNode configuration
 
+### Node
+
 `NETWORK`: Select the Starknet network to sync (default: "mainnet"). Available options:
 
 - **mainnet**: Mainnet network (~172 GB snapshot)
@@ -46,6 +48,25 @@ Or using the full domain:
 `WS_HOST`: WebSocket server host interface (default: "0.0.0.0"). See [WebSocket Interface](https://juno.nethermind.io/websocket)
 
 `EXTRA_OPTS`: Additional configuration options. See [Configuration options](https://juno.nethermind.io/configuring#configuration-options)
+
+### Validator
+
+> ⚠️ Warning: Do not start the staking container before Juno is fully synced. Otherwise, it will broadcast outdated attestations on the network. To make sure it doesn't attest while syncing, keep the SIGNER_* variables empty until it's ready.
+
+`PROVIDER_HTTP_URL`: The Juno HTTP RPC URL (default `http://juno:6060/rpc/v0_8`)
+
+`PROVIDER_WS_URL`: The Juno Websocket RPC URL (default `ws://juno:6061/ws/v0_8`)
+
+`SIGNER_OPERATIONAL_ADDRESS`: The staking operational address
+
+`SIGNER_PRIVATE_KEY`: The staking signer private key (optional)
+
+`SIGNER_EXTERNAL_URL`: The staking external signer URL (optional)
+
+
+Note: One of signer private key OR external URL is required. 
+See the [Starknet Staking v2 configuration page](https://nethermindeth.github.io/starknet-staking-v2/configuration) for more details on the parameters. 
+
 
 ## Network Configuration Examples
 

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "juno.public.dappnode.eth",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "shortDescription": "StarkNet full node",
   "description": "Nethermind Starknet Node Client Juno",
   "type": "service",

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "juno.public.dappnode.eth",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "shortDescription": "StarkNet full node",
   "description": "Nethermind Starknet Node Client Juno",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v0.15.0-rc.4
+        UPSTREAM_VERSION: v0.15.0
     image: juno.public.dappnode.eth:2.0.0
     security_opt:
       - seccomp:unconfined

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v0.15.0
-    image: juno.public.dappnode.eth:2.0.3
+        UPSTREAM_VERSION: v0.15.5
+    image: juno.public.dappnode.eth:2.0.4
     security_opt:
       - seccomp:unconfined
     ports:
@@ -21,6 +21,15 @@ services:
       EXTRA_OPTS: ""
     volumes:
       - juno_data:/var/lib/juno
+    restart: unless-stopped
+  staking:
+    image: nethermind/starknet-staking-v2
+    environment:
+      PROVIDER_HTTP_URL: http://juno:6060/rpc/v0_8
+      PROVIDER_WS_URL: ws://juno:6061/ws/v0_8
+      SIGNER_OPERATIONAL_ADDRESS: ""
+      SIGNER_PRIVATE_KEY: ""
+      SIGNER_EXTERNAL_URL: ""
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "6060:6060"
       - "6061:6061"
     environment:
-      ETH_L1_RPC_URL: http://execution.mainnet.staker.dappnode:8545
+      ETH_L1_RPC_URL: ws://execution.mainnet.staker.dappnode:8546
       SNAPSHOT_URL: https://juno-snapshots.nethermind.io/files/mainnet/latest
       NETWORK: mainnet
       ENABLE_WS: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       args:
         UPSTREAM_VERSION: v0.15.0
-    image: juno.public.dappnode.eth:2.0.0
+    image: juno.public.dappnode.eth:2.0.3
     security_opt:
       - seccomp:unconfined
     ports:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ fi
 wsopts=""
 if [ "$ENABLE_WS" = "true" ]; then
   echo "WebSocket interface enabled."
-  wsopts="--ws true --ws-port ${WS_PORT:-6061} --ws-host ${WS_HOST:-0.0.0.0}"
+  wsopts="--ws --ws-port ${WS_PORT:-6061} --ws-host ${WS_HOST:-0.0.0.0}"
 fi
 
 juno \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,13 +15,11 @@ echo "Extra options: $EXTRA_OPTS"
 
 # if dir is empty and URL is configured, download the snapshot
 if [ "$(ls -A $JUNO_DIR)" ]; then
-  echo "Skipping snapshot download."
+  echo "Juno data directory is not empty, skipping snapshot download."
 elif [ -n "$SNAPSHOT_URL" ]; then
   echo "Juno data directory is empty. Downloading snapshot."
-  snapshot=mainnet.tar
-  wget --progress=dot:giga -O $snapshot $SNAPSHOT_URL
-  tar --checkpoint=65536 -xf $snapshot -C $JUNO_DIR
-  rm $snapshot
+  checkpoint_action=="echo -n \"Extracted: \" && echo \$((\$TAR_CHECKPOINT * 512 * \$TAR_BLOCKING_FACTOR)) | numfmt --to=iec-i --suffix=B"
+  curl -s -L $SNAPSHOT_URL | zstd -d | tar --checkpoint=16384 --checkpoint-action=exec="$checkpoint_action" -xf - -C $JUNO_DIR
 fi
 
 ethnode=""


### PR DESCRIPTION
Hello @ArturVargas , I made this update to include [Nethermind Starknet Staking v2](https://nethermindeth.github.io/starknet-staking-v2).

I saw that you started a branch with Juno validator configuration but I couldn't find any documentation about it. I tested the staking-v2 solution and my validator is now attesting on the network. 
Feel free to merge in some of the improvements you made on your branch. 

Also, there's a catch: if the node is still syncing (I tried a resync from the snapshot to validate the new version), then the staking program will send outdated attestations. Maybe it's a bug for the staking-v2 project but it could be nice to be able to start the staking only when the node is ready. 

Best,
Louis